### PR TITLE
fix links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Geofencing
 ==========
 
-A [spec for ServiceWorker-based Geofencing](https://slightlyoff.github.io/Geofence/spec/) and an [explainer document](https://github.com/slightlyoff/Geofence/blob/master/explainer.md) to describe the motivation and usage for this feature.
+A [spec for ServiceWorker-based Geofencing](https://slightlyoff.github.io/Geofencing/spec/) and an [explainer document](https://github.com/slightlyoff/Geofencing/blob/master/explainer.md) to describe the motivation and usage for this feature.


### PR DESCRIPTION
I also noticed https://slightlyoff.github.io/Geofencing/spec/ 404s because there is no `gh-pages` branch.
